### PR TITLE
feat: restructure Terraform into environments/modules layout

### DIFF
--- a/eks-main.tf
+++ b/eks-main.tf
@@ -2,143 +2,33 @@ provider "aws" {
   region = var.aws_region
 }
 
-#VPC for Cluster
 data "aws_availability_zones" "azs" {
   state = "available"
-} #queries AWS to provide the names of availability zones dynamically
-
-module "vpc" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 6.0"
-
-  name            = "${var.project_name}-vpc"
-  cidr            = var.vpc_cidr_block
-  private_subnets = var.private_subnets_cidr
-  public_subnets  = var.public_subnets_cidr
-  azs             = data.aws_availability_zones.azs.names
-
-  enable_nat_gateway   = true
-  single_nat_gateway   = true
-  enable_dns_support   = true
-  enable_dns_hostnames = true
-
-  tags = {
-    "kubernetes.io/cluster/${var.project_name}-eks-cluster" = "shared" # Tags required for EKS to discover subnets
-    Terraform                                               = "true"
-    Environment                                             = var.environment
-  }
-
-  public_subnet_tags = {
-    "kubernetes.io/cluster/${var.project_name}-eks-cluster" = "shared"
-    "kubernetes.io/role/elb"                                = 1 # Identifies this subnet for external load balancers
-  }
-
-  private_subnet_tags = {
-    "kubernetes.io/cluster/${var.project_name}-eks-cluster" = "shared"
-    "kubernetes.io/role/internal-elb"                       = 1 # Identifies this subnet for internal services
-  }
 }
 
-#EKS for Cluster
+module "vpc" {
+  source = "./modules/vpc"
+
+  project_name         = var.project_name
+  environment          = var.environment
+  vpc_cidr_block       = var.vpc_cidr_block
+  private_subnets_cidr = var.private_subnets_cidr
+  public_subnets_cidr  = var.public_subnets_cidr
+  availability_zones   = data.aws_availability_zones.azs.names
+}
+
 module "eks" {
-  source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.1"
+  source = "./modules/eks"
 
-  name               = "${var.project_name}-eks-cluster"
-  kubernetes_version = var.kubernetes_version
-
-  vpc_id     = module.vpc.vpc_id
-  subnet_ids = module.vpc.private_subnets
-
-  endpoint_public_access = true
-
-  addons = {
-    coredns                = {}
-    eks-pod-identity-agent = { before_compute = true }
-    kube-proxy             = {}
-    vpc-cni                = { before_compute = true }
-  }
-
-  # Set authentication mode to API
-  authentication_mode = "API"
-
-  # Adds the current caller identity as an administrator via cluster access entry
-  enable_cluster_creator_admin_permissions = true
-
-  # Add access entries
-  access_entries = {
-    admin = {
-      principal_arn = aws_iam_role.external-admin.arn
-      username      = "admin"
-      type          = "STANDARD"
-
-      # Grant admin access with admin access-policy
-      policy_associations = {
-        viewer = {
-          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
-          access_scope = {
-            type = "cluster"
-          }
-        }
-      }
-    }
-    developer = {
-      principal_arn = aws_iam_role.external-developer.arn
-      username      = "developer"
-      type          = "STANDARD"
-
-      # Grant developer access with view-only permissions to specific namespace
-      policy_associations = {
-        viewer = {
-          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy"
-          access_scope = {
-            type       = "namespace"
-            namespaces = ["online-boutique"]
-          }
-        }
-      }
-    }
-  }
-
-  eks_managed_node_groups = {
-    dev = {
-      instance_types = var.node_group_instance_types
-      min_size       = var.node_group_min_size
-      max_size       = var.node_group_max_size
-      desired_size   = var.node_group_desired_size
-      tags = {
-        "k8s.io/cluster-autoscaler/enabled"                         = "true"
-        "k8s.io/cluster-autoscaler/${var.project_name}-eks-cluster" = "owned"
-      }
-    }
-  }
-
-  node_security_group_additional_rules = {
-
-    #Enables automatic sidecar injection when pods are created
-    ingress_15017 = {
-      description                   = "Cluster API to Istio Webhook namespace.sidecar-injector.istio.io"
-      protocol                      = "TCP"
-      from_port                     = 15017
-      to_port                       = 15017
-      type                          = "ingress"
-      source_cluster_security_group = true
-    }
-
-    #Enables service discovery and configuration distribution
-    ingress_15012 = {
-      description                   = "Cluster API to nodes ports/protocols"
-      protocol                      = "TCP"
-      from_port                     = 15012
-      to_port                       = 15012
-      type                          = "ingress"
-      source_cluster_security_group = true
-    }
-  }
-
-  tags = {
-    environment = var.environment
-    terraform   = true
-  }
-
+  project_name              = var.project_name
+  environment               = var.environment
+  kubernetes_version        = var.kubernetes_version
+  vpc_id                    = module.vpc.vpc_id
+  private_subnets           = module.vpc.private_subnets
+  admin_role_arn            = aws_iam_role.external-admin.arn
+  developer_role_arn        = aws_iam_role.external-developer.arn
+  node_group_instance_types = var.node_group_instance_types
+  node_group_min_size       = var.node_group_min_size
+  node_group_max_size       = var.node_group_max_size
+  node_group_desired_size   = var.node_group_desired_size
 }

--- a/environments/dev/terraform.tfvars
+++ b/environments/dev/terraform.tfvars
@@ -1,0 +1,18 @@
+# Environment
+aws_region   = "us-east-2"
+project_name = "eks-platform"
+environment  = "dev"
+
+# Kubernetes
+kubernetes_version = "1.33"
+
+# Networking
+vpc_cidr_block       = "10.0.0.0/16"
+private_subnets_cidr = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+public_subnets_cidr  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+
+# Node Group
+node_group_instance_types = ["t3.medium"]
+node_group_min_size       = 1
+node_group_max_size       = 3
+node_group_desired_size   = 1

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -1,0 +1,89 @@
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 21.1"
+
+  name               = "${var.project_name}-eks-cluster"
+  kubernetes_version = var.kubernetes_version
+
+  vpc_id     = var.vpc_id
+  subnet_ids = var.private_subnets
+
+  endpoint_public_access = true
+
+  addons = {
+    coredns                = {}
+    eks-pod-identity-agent = { before_compute = true }
+    kube-proxy             = {}
+    vpc-cni                = { before_compute = true }
+  }
+
+  authentication_mode                      = "API"
+  enable_cluster_creator_admin_permissions = true
+
+  access_entries = {
+    admin = {
+      principal_arn = var.admin_role_arn
+      username      = "admin"
+      type          = "STANDARD"
+      policy_associations = {
+        viewer = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = {
+            type = "cluster"
+          }
+        }
+      }
+    }
+    developer = {
+      principal_arn = var.developer_role_arn
+      username      = "developer"
+      type          = "STANDARD"
+      policy_associations = {
+        viewer = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy"
+          access_scope = {
+            type       = "namespace"
+            namespaces = ["online-boutique"]
+          }
+        }
+      }
+    }
+  }
+
+  eks_managed_node_groups = {
+    dev = {
+      instance_types = var.node_group_instance_types
+      min_size       = var.node_group_min_size
+      max_size       = var.node_group_max_size
+      desired_size   = var.node_group_desired_size
+      tags = {
+        "k8s.io/cluster-autoscaler/enabled"                         = "true"
+        "k8s.io/cluster-autoscaler/${var.project_name}-eks-cluster" = "owned"
+      }
+    }
+  }
+
+  node_security_group_additional_rules = {
+    ingress_15017 = {
+      description                   = "Cluster API to Istio Webhook namespace.sidecar-injector.istio.io"
+      protocol                      = "TCP"
+      from_port                     = 15017
+      to_port                       = 15017
+      type                          = "ingress"
+      source_cluster_security_group = true
+    }
+    ingress_15012 = {
+      description                   = "Cluster API to nodes ports/protocols"
+      protocol                      = "TCP"
+      from_port                     = 15012
+      to_port                       = 15012
+      type                          = "ingress"
+      source_cluster_security_group = true
+    }
+  }
+
+  tags = {
+    environment = var.environment
+    terraform   = true
+  }
+}

--- a/modules/eks/outputs.tf
+++ b/modules/eks/outputs.tf
@@ -1,24 +1,6 @@
-output "cluster_endpoint" {
-  description = "EKS cluster API endpoint."
-  value       = module.eks.cluster_endpoint
-}
-
-output "cluster_certificate_authority_data" {
-  description = "Base64 encoded certificate authority data."
-  value       = module.eks.cluster_certificate_authority_data
-}
-
-output "cluster_name" {
-  description = "Name of the EKS cluster."
-  value       = module.eks.cluster_name
-}
-
-output "cluster_security_group_id" {
-  description = "Security group ID attached to the EKS cluster."
-  value       = module.eks.cluster_security_group_id
-}
-
-output "oidc_provider_arn" {
-  description = "ARN of the OIDC provider for IRSA."
-  value       = module.eks.oidc_provider_arn
-}
+output "cluster_endpoint" { value = module.eks.cluster_endpoint }
+output "cluster_certificate_authority_data" { value = module.eks.cluster_certificate_authority_data }
+output "cluster_name" { value = module.eks.cluster_name }
+output "cluster_version" { value = module.eks.cluster_version }
+output "cluster_security_group_id" { value = module.eks.cluster_security_group_id }
+output "oidc_provider_arn" { value = module.eks.oidc_provider_arn }

--- a/modules/eks/outputs.tf
+++ b/modules/eks/outputs.tf
@@ -1,0 +1,24 @@
+output "cluster_endpoint" {
+  description = "EKS cluster API endpoint."
+  value       = module.eks.cluster_endpoint
+}
+
+output "cluster_certificate_authority_data" {
+  description = "Base64 encoded certificate authority data."
+  value       = module.eks.cluster_certificate_authority_data
+}
+
+output "cluster_name" {
+  description = "Name of the EKS cluster."
+  value       = module.eks.cluster_name
+}
+
+output "cluster_security_group_id" {
+  description = "Security group ID attached to the EKS cluster."
+  value       = module.eks.cluster_security_group_id
+}
+
+output "oidc_provider_arn" {
+  description = "ARN of the OIDC provider for IRSA."
+  value       = module.eks.oidc_provider_arn
+}

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -1,0 +1,54 @@
+variable "project_name" {
+  description = "Prefix applied to all resource names."
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment (dev, staging, prod)."
+  type        = string
+}
+
+variable "kubernetes_version" {
+  description = "EKS Kubernetes version."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC to deploy the cluster into."
+  type        = string
+}
+
+variable "private_subnets" {
+  description = "List of private subnet IDs for worker nodes."
+  type        = list(string)
+}
+
+variable "admin_role_arn" {
+  description = "ARN of the IAM role granted cluster admin access."
+  type        = string
+}
+
+variable "developer_role_arn" {
+  description = "ARN of the IAM role granted developer read-only access."
+  type        = string
+}
+
+variable "node_group_instance_types" {
+  description = "EC2 instance types for the managed node group."
+  type        = list(string)
+}
+
+variable "node_group_min_size" {
+  description = "Minimum number of nodes."
+  type        = number
+}
+
+variable "node_group_max_size" {
+  description = "Maximum number of nodes."
+  type        = number
+}
+
+variable "node_group_desired_size" {
+  description = "Desired number of nodes."
+  type        = number
+}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,0 +1,31 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 6.0"
+
+  name            = "${var.project_name}-vpc"
+  cidr            = var.vpc_cidr_block
+  private_subnets = var.private_subnets_cidr
+  public_subnets  = var.public_subnets_cidr
+  azs             = var.availability_zones
+
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    "kubernetes.io/cluster/${var.project_name}-eks-cluster" = "shared"
+    Terraform                                               = "true"
+    Environment                                             = var.environment
+  }
+
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${var.project_name}-eks-cluster" = "shared"
+    "kubernetes.io/role/elb"                                = 1
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${var.project_name}-eks-cluster" = "shared"
+    "kubernetes.io/role/internal-elb"                       = 1
+  }
+}

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -1,0 +1,14 @@
+output "vpc_id" {
+  description = "ID of the VPC."
+  value       = module.vpc.vpc_id
+}
+
+output "private_subnets" {
+  description = "List of private subnet IDs."
+  value       = module.vpc.private_subnets
+}
+
+output "public_subnets" {
+  description = "List of public subnet IDs."
+  value       = module.vpc.public_subnets
+}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -1,0 +1,29 @@
+variable "project_name" {
+  description = "Prefix applied to all resource names."
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment (dev, staging, prod)."
+  type        = string
+}
+
+variable "vpc_cidr_block" {
+  description = "CIDR block for the VPC."
+  type        = string
+}
+
+variable "private_subnets_cidr" {
+  description = "CIDR blocks for private subnets."
+  type        = list(string)
+}
+
+variable "public_subnets_cidr" {
+  description = "CIDR blocks for public subnets."
+  type        = list(string)
+}
+
+variable "availability_zones" {
+  description = "List of availability zones to use."
+  type        = list(string)
+}


### PR DESCRIPTION
## What
- Extracted VPC and EKS configuration into local reusable modules under `modules/vpc` and `modules/eks`
- Added `environments/dev/terraform.tfvars` with dev-specific values
- Root `eks-main.tf` now calls local modules instead of community modules directly

## Why
- Separation of concerns — infrastructure logic lives in modules, environment config lives in environments/
- Enables staging/prod environments to reuse the same modules with different tfvars
- Follows Terraform best practices for scalable IaC structure

## What stays the same
- Backend config unchanged
- All platform add-ons (ArgoCD, Kyverno, Prometheus etc.) unchanged
- CI/CD workflows unchanged — still targets root